### PR TITLE
WIP: Make supervisor name configurable

### DIFF
--- a/lib/kungfuig.ex
+++ b/lib/kungfuig.ex
@@ -163,10 +163,11 @@ defmodule Kungfuig do
     end
   end
 
-  @spec config(which :: atom() | [atom()] | nil) :: Kungfuig.t()
-  def config(which \\ nil) do
+  @spec config(supervisor :: Supervisor.supervisor(), which :: atom() | [atom()] | nil) ::
+          Kungfuig.t()
+  def config(supervisor \\ Kungfuig.Supervisor, which \\ nil) do
     result =
-      Kungfuig.Supervisor
+      supervisor
       |> Supervisor.which_children()
       |> Enum.find(&match?({_, _, :worker, _}, &1))
       |> case do

--- a/lib/kungfuig/supervisor.ex
+++ b/lib/kungfuig/supervisor.ex
@@ -6,7 +6,9 @@ defmodule Kungfuig.Supervisor do
   alias Kungfuig.{Backends, Blender, Manager}
 
   def start_link(opts \\ []) do
-    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+    # Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    Supervisor.start_link(__MODULE__, opts, name: name)
   end
 
   @impl true

--- a/lib/kungfuig/supervisor.ex
+++ b/lib/kungfuig/supervisor.ex
@@ -6,7 +6,6 @@ defmodule Kungfuig.Supervisor do
   alias Kungfuig.{Backends, Blender, Manager}
 
   def start_link(opts \\ []) do
-    # Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
     {name, opts} = Keyword.pop(opts, :name, __MODULE__)
     Supervisor.start_link(__MODULE__, opts, name: name)
   end

--- a/test/kungfuig_test.exs
+++ b/test/kungfuig_test.exs
@@ -5,6 +5,7 @@ defmodule Kungfuig.Test do
   test "custom target" do
     {:ok, pid} =
       Kungfuig.Supervisor.start_link(
+        name: :server_1,
         blender:
           {Kungfuig.Blender,
            interval: 100,
@@ -15,14 +16,19 @@ defmodule Kungfuig.Test do
     assert_receive {:updated, %{env: %{kungfuig: []}}}, 1_010
 
     Application.put_env(:kungfuig, :foo, 42)
+
     assert_receive {:updated, %{env: %{kungfuig: [foo: 42]}}}, 1_010
 
     System.put_env("KUNGFUIG_FOO", "42")
     assert_receive {:updated, %{system: %{"KUNGFUIG_FOO" => "42"}}}, 1_010
 
-    assert Kungfuig.config() == %{env: %{kungfuig: [foo: 42]}, system: %{"KUNGFUIG_FOO" => "42"}}
+    assert Kungfuig.config(:server_1) == %{
+             env: %{kungfuig: [foo: 42]},
+             system: %{"KUNGFUIG_FOO" => "42"}
+           }
 
     Application.delete_env(:kungfuig, :foo)
+    System.delete_env("KUNGFUIG_FOO")
     Supervisor.stop(pid)
   end
 
@@ -49,5 +55,39 @@ defmodule Kungfuig.Test do
 
     Application.delete_env(:kungfuig, :foo_transform)
     Supervisor.stop(pid)
+  end
+
+  test "custom target with via registered name" do
+    {:ok, _} = Registry.start_link(keys: :unique, name: Registry.ViaTest)
+    name = {:via, Registry, {Registry.ViaTest, "server_2"}}
+
+    {:ok, pid} =
+      Kungfuig.Supervisor.start_link(
+        name: name,
+        blender:
+          {Kungfuig.Blender,
+           interval: 100,
+           validator: Kungfuig.Validators.Env,
+           callback: {self(), {:info, :updated}}}
+      )
+
+    assert_receive {:updated, %{env: %{kungfuig: []}}}, 1_010
+
+    Application.put_env(:kungfuig, :bar, 24)
+
+    assert_receive {:updated, %{env: %{kungfuig: [bar: 24]}}}, 1_010
+
+    System.put_env("KUNGFUIG_BAR", "24")
+    assert_receive {:updated, %{system: %{"KUNGFUIG_BAR" => "24"}}}, 1_010
+
+    assert Kungfuig.config(name) == %{
+             env: %{kungfuig: [bar: 24]},
+             system: %{"KUNGFUIG_BAR" => "24"}
+           }
+
+    Application.delete_env(:kungfuig, :bar)
+    System.delete_env("KUNGFUIG_BAR")
+    Supervisor.stop(pid)
+    Registry.unregister(Registry.ViaTest, "server_2")
   end
 end


### PR DESCRIPTION
I added a third test for a name registered with a `:via` tuple. The first test is now using an atom for the server name, second test omits a name, and third test uses a registered name. 

All test are passing, however, I'm getting the following Logger Info notification from `Kungfuig.Backend report(error)` `line: 43`:

`[info]  Failed to retrieve config in env_transform. Error: %NimbleOptions.ValidationError{key: :foo_transform, keys_path: [], message: "expected :foo_transform to be an atom, got: 42", value: 42}.`

